### PR TITLE
fix: replace slice() to strpart()

### DIFF
--- a/plugin/template.vim
+++ b/plugin/template.vim
@@ -130,10 +130,10 @@ function! LoadTemplate()
     while 1
       let index = stridx(fullFileName, ".", lastIndex)
       if (index >= 0)
-        let ext = slice(fullFileName, index)
+        let ext = strpart(fullFileName, index)
         if filereadable(g:template_dir . '/template' . ext)
           let fileExt = ext
-          let fileName = slice(fullFileName, 0, index)
+          let fileName = strpart(fullFileName, 0, index)
           break
         endif
         let lastIndex = index + 1


### PR DESCRIPTION
string width in slice(中文, start, end) is difference to stridx()

`:h expr-[:]`

```
stridx("中文.md", ".", 0) => 6
slice("中文.md", 6) => ""
slice("中文.md", 0, 1) => "中"
slice("中文.md", 1, 2) => "文"
strpart("中文.md", 0, 6) => "中文"
strpart("中文.md", 0, 3) => "中"
strpart("中文.md", 3, 6) => "文"
```