### PR TITLE
fix: allow g:template_autoload to be set to boolean value

### DIFF
--- a/plugin/template.vim
+++ b/plugin/template.vim
@@ -178,7 +178,7 @@ function! LoadTemplate()
   return ''
 endfunction
 
-if 0 != g:template_autoload
+if g:template_autoload
   autocmd! BufNewFile * silent! :call LoadTemplate()
 endif
 command! -nargs=0 Template call LoadTemplate()


### PR DESCRIPTION
Previous test was whether variable was zero or non-zero. This did not allow for it to be set to v:true or v:false. Changing the test to evaluate whether true or not allows for boolean values, which is compatible with nvim lua plugin files setting the variable to lua true or false.